### PR TITLE
Implement new cli commands for inspecting profiles

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -34,6 +34,14 @@ pub enum Cmd {
 
 #[derive(Subcommand, Debug)]
 pub enum ProfileCmd {
+    /// List existing profiles
+    List,
+    /// Inspect a profile
+    Show {
+        /// Name of the profile
+        #[arg(value_parser = | name: & str | Profile::read_json(name))]
+        profile: Profile,
+    },
     // TODO now it overrides existing profiles, make it warn in such case and add --force flag
     /// Add a new profile
     Add {

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,8 @@ fn main() {
             Cmd::Profile { command } => {
                 if let Some(prof_cmd) = command {
                     match prof_cmd {
+                        ProfileCmd::List => {}
+                        ProfileCmd::Show { .. } => {}
                         ProfileCmd::Add { name, user_name, user_email } => {
                             let profile = Profile::new(name, user_name, user_email);
                             generate_profile(profile);

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 
 use crate::cli::{Cli, Cmd, ProfileCmd};
 use crate::git::{clone, configure_user};
-use crate::profile::{edit_profile, generate_profile, remove_profile};
+use crate::profile::{edit_profile, generate_profile, list_profiles, remove_profile};
 use crate::profile::profile::Profile;
 
 mod cli;
@@ -22,8 +22,12 @@ fn main() {
             Cmd::Profile { command } => {
                 if let Some(prof_cmd) = command {
                     match prof_cmd {
-                        ProfileCmd::List => {}
-                        ProfileCmd::Show { .. } => {}
+                        ProfileCmd::List => {
+                            list_profiles();
+                        }
+                        ProfileCmd::Show { profile } => {
+                            println!("{profile:#?}")
+                        }
                         ProfileCmd::Add { name, user_name, user_email } => {
                             let profile = Profile::new(name, user_name, user_email);
                             generate_profile(profile);

--- a/src/profile/profile.rs
+++ b/src/profile/profile.rs
@@ -8,6 +8,10 @@ use crate::profile::Result;
 const HOME: &str = env!("HOME");
 const PROFILES_DIR: &str = ".config/git-multiaccount-profiles";
 
+pub fn profiles_dir() -> String {
+    format!("{HOME}/{PROFILES_DIR}")
+}
+
 pub fn profile_path(profile_name: &str) -> String {
     let profiles_dir = format!("{HOME}/{PROFILES_DIR}");
     format!("{profiles_dir}/{profile_name}.json")


### PR DESCRIPTION
 Added 2 new cli subcommands for `profile`:
 1. `list` - list existing profiles
 2. `show <PROFILE>` - inspect chosen profile